### PR TITLE
fix: swagger server url

### DIFF
--- a/src/main/kotlin/ru/itmo/tps/TpsApplication.kt
+++ b/src/main/kotlin/ru/itmo/tps/TpsApplication.kt
@@ -1,9 +1,16 @@
 package ru.itmo.tps
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.servers.Server
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 
+
+
+@OpenAPIDefinition(
+    servers = [Server(url = "/", description="Your host")]
+)
 @SpringBootApplication
 @EnableCaching
 class TpsApplication

--- a/src/main/kotlin/ru/itmo/tps/TpsApplication.kt
+++ b/src/main/kotlin/ru/itmo/tps/TpsApplication.kt
@@ -6,8 +6,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 
-
-
 @OpenAPIDefinition(
     servers = [Server(url = "/", description="Your host")]
 )


### PR DESCRIPTION
If you decide to host this app on your server, swagger would use url from Host header, which is wrong if you use https or just proxy passing it (example below)

![](https://i.imgur.com/tHvKHSZ.png)

With this fix however it look like this and it works fine

![](https://i.imgur.com/c5SbTsB.png)